### PR TITLE
added optional environment configuration

### DIFF
--- a/src/rollbar.config.ts
+++ b/src/rollbar.config.ts
@@ -129,4 +129,12 @@ export interface RollbarPayload {
             code_version: string;
         }
     }
+    
+    /**
+     * rollbar log environment (e.g. production, staging, etc.)
+     * 
+     * @type {string}
+     * @memberOf RollbarPayload
+     */
+    environment?: string;
 }


### PR DESCRIPTION
The RollbarPayload now has a new optional configuration value "environment" that corresponds to the rollbar error tracking environment.

This pr fixes #4 and has been tested internally.